### PR TITLE
Support yarn installer

### DIFF
--- a/{{cookiecutter.dir_name}}/Makefile
+++ b/{{cookiecutter.dir_name}}/Makefile
@@ -1,5 +1,15 @@
 .PHONY: build
 
+
+NPM:=$(shell which npm)
+YARN:=$(shell which yarn)
+
+installer = $(NPM)
+
+ifdef YARN
+	installer = $(YARN)
+endif
+
 all: run
 
 run: node_modules  ## Run the server
@@ -12,7 +22,7 @@ build: node_modules  ## Compile a project for deployment
 	./node_modules/.bin/webpack  --progress --colors --devtool source-map
 
 node_modules: package.json
-	npm install
+	$(installer) install
 
 .PHONY: help
 


### PR DESCRIPTION
Yarn's the hot-new-thing from facebook, so...support for that by default. If installed the makefile will use that, if not it will fall back to npm.
